### PR TITLE
Need pkg-config in all cases

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,9 @@
 
 source "http://rubygems.org/"
 
+gem 'pkg-config'
+
 group :development, :test do
-  gem 'pkg-config'
   gem "test-unit"
   gem "test-unit-notify"
   gem "rake"


### PR DESCRIPTION
The pkg-config gem is required to compile the C units, so it is a full dependency not a development/test-only dependency.  Updated the Gemfile to reflect this so the gem will hopefully install correctly.
