### PR TITLE
Add missing cairo-quartz-image.h include

### DIFF
--- a/ext/cairo/rb_cairo.h
+++ b/ext/cairo/rb_cairo.h
@@ -35,10 +35,6 @@
 #  include <cairo-script.h>
 #endif
 
-#ifdef CAIRO_HAS_QUARTZ_IMAGE_SURFACE
-#  include <cairo-quartz-image.h>
-#endif
-
 #define CAIRO_CHECK_VERSION(major, minor, micro)    \
     (CAIRO_VERSION_MAJOR > (major) || \
      (CAIRO_VERSION_MAJOR == (major) && CAIRO_VERSION_MINOR > (minor)) || \

--- a/ext/cairo/rb_cairo_surface.c
+++ b/ext/cairo/rb_cairo_surface.c
@@ -1453,6 +1453,9 @@ cr_win32_printing_surface_initialize (VALUE self, VALUE hdc)
 #endif
 
 #ifdef RB_CAIRO_HAS_QUARTZ_IMAGE_SURFACE
+
+#include <cairo-quartz-image.h>
+
 /* Quartz image surface functions */
 static VALUE
 cr_quartz_image_surface_initialize (VALUE self, VALUE image_surface)


### PR DESCRIPTION
Because following warnings generate in OS X 10.9:

``` log
rb_cairo_surface.c:1462:13: warning: implicit declaration of function 'cairo_quartz_image_surface_create' is invalid in C99 [-Wimplicit-function-declaration]
  surface = cairo_quartz_image_surface_create (RVAL2CRSURFACE (image_surface));
            ^
rb_cairo_surface.c:1462:11: warning: incompatible integer to pointer conversion assigning to 'cairo_surface_t *' (aka 'struct _cairo_surface *') from 'int' [-Wint-conversion]
  surface = cairo_quartz_image_surface_create (RVAL2CRSURFACE (image_surface));
          ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
rb_cairo_surface.c:1475:13: warning: implicit declaration of function 'cairo_quartz_image_surface_get_image' is invalid in C99 [-Wimplicit-function-declaration]
  surface = cairo_quartz_image_surface_get_image (_SELF);
            ^
rb_cairo_surface.c:1475:11: warning: incompatible integer to pointer conversion assigning to 'cairo_surface_t *' (aka 'struct _cairo_surface *') from 'int' [-Wint-conversion]
  surface = cairo_quartz_image_surface_get_image (_SELF);
          ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
