### PR TITLE
implement `Cairo::FontFace.quartz_supported?` and use this in test

### DIFF
--- a/ext/cairo/rb_cairo_font_face.c
+++ b/ext/cairo/rb_cairo_font_face.c
@@ -111,6 +111,16 @@ cr_font_face_allocate (VALUE klass)
   return Data_Wrap_Struct (klass, NULL, cr_font_face_free, NULL);
 }
 
+static VALUE
+cr_font_face_quartz_supported_p (VALUE klass)
+{
+#ifdef CAIRO_HAS_QUARTZ_FONT
+  return Qtrue;
+#else
+  return Qfalse;
+#endif
+}
+
 #if CAIRO_CHECK_VERSION(1, 7, 6)
 static VALUE
 cr_toy_font_face_initialize (int argc, VALUE *argv, VALUE self)
@@ -651,6 +661,9 @@ Init_cairo_font (void)
   rb_cCairo_FontFace =
     rb_define_class_under (rb_mCairo, "FontFace", rb_cObject);
   rb_define_alloc_func (rb_cCairo_FontFace, cr_font_face_allocate);
+
+  rb_define_singleton_method (rb_cCairo_FontFace, "quartz_supported?",
+                              cr_font_face_quartz_supported_p, 0);
 
 #if CAIRO_CHECK_VERSION(1, 7, 6)
   rb_cCairo_ToyFontFace =

--- a/test/cairo-test-utils.rb
+++ b/test/cairo-test-utils.rb
@@ -17,6 +17,10 @@ module CairoTestUtils
     /cygwin|mingw|mswin32|bccwin32/.match(RUBY_PLATFORM) ? true : false
   end
 
+  def quartz?
+    Cairo::FontFace.quartz_supported?
+  end
+
   def only_device(name)
     only_cairo_version(1, 10)
 

--- a/test/test_context.rb
+++ b/test/test_context.rb
@@ -73,7 +73,7 @@ class ContextTest < Test::Unit::TestCase
 
     face = context.font_face
     default_font_family = ""
-    # default_font_family = "Helvetica" if quartz?
+    default_font_family = "Helvetica" if quartz?
     default_font_family = "Arial" if win32?
     assert_equal([default_font_family,
                   Cairo::FONT_SLANT_NORMAL,

--- a/test/test_font_face.rb
+++ b/test/test_font_face.rb
@@ -8,7 +8,7 @@ class FontFaceTest < Test::Unit::TestCase
 
     face = Cairo::ToyFontFace.new
     default_font_family = ""
-    # default_font_family = "Helvetica" if quartz?
+    default_font_family = "Helvetica" if quartz?
     default_font_family = "Arial" if win32?
     assert_equal([default_font_family,
                   Cairo::FONT_SLANT_NORMAL,


### PR DESCRIPTION
I've rebased and squashed commits #26 .

"Helvetica" is specified in cairo/cairoint.h as follows:

```
#define CAIRO_QUARTZ_FONT_FAMILY_DEFAULT  "Helvetica"
```

this definition is redfined:

```
#define CAIRO_FONT_FAMILY_DEFAULT CAIRO_QUARTZ_FONT_FAMILY_DEFAULT
```

And used in `_cairo_gstate_ensure_font_face()`

```
font_face = cairo_toy_font_face_create (CAIRO_FONT_FAMILY_DEFAULT,
                                        CAIRO_FONT_SLANT_DEFAULT,
                                        CAIRO_FONT_WEIGHT_DEFAULT);
```

and `_cairo_gstate_ensure_font_face()` is used in
`cairo_get_font_face()`.

So it is suitable `Cairo::FontFace.quartz_supported?` definition place
in Cairo::FontFace, isn't it?

implement `quartz?` in CairoTestUtils
