### PR TITLE
fix compilation error not found `cairo-quartz-image.h` in OS X

### DIFF
--- a/ext/cairo/extconf.rb
+++ b/ext/cairo/extconf.rb
@@ -198,6 +198,5 @@ have_header("ruby/st.h") unless have_macro("HAVE_RUBY_ST_H", "ruby.h")
 have_header("ruby/io.h") unless have_macro("HAVE_RUBY_IO_H", "ruby.h")
 have_func("rb_errinfo", "ruby.h")
 have_type("enum ruby_value_type", "ruby.h")
-have_header("cairo-quartz-image.h") if have_macro("CAIRO_HAS_QUARTZ_SURFACE", "cairo.h")
 
 create_makefile(module_name)


### PR DESCRIPTION
`cairo-quratz-image.h` is not always installed.
Simply installation cairo in OS X with Homebrew as follows:

```
% brew install cairo
```

Homebrew's cairo Bottle is not fully enabled quartz feature.
So, it is not installed `cairo-quartz-image.h`.
This lack of existence of `cairo-quartz-image.h` causes following error:

``` log
compiling rb_cairo_surface.c
rb_cairo_surface.c:58:14: fatal error: 'cairo-quartz-image.h' file not
found
 #    include <cairo-quartz-image.h>
              ^
              1 error generated.
              make[1]: *** [rb_cairo_surface.o] Error 1
              make: *** [all] Error 2
```

Instead, following installation is also installing `cairo-quartz-image.h`

```
% brew install cairo --without-x11
```

It seems that it needs check `cairo-quartz-image.h` existence before it include `cairo-quartz-image.h`.
