### PR TITLE
fix imcompatible pointer type casting warning in Cairo::QuartzSurface#initialize

### DIFF
--- a/ext/cairo/rb_cairo_surface.c
+++ b/ext/cairo/rb_cairo_surface.c
@@ -1278,7 +1278,7 @@ cr_quartz_surface_initialize (int argc, VALUE *argv, VALUE self)
                   rb_objc_pointer = rb_funcall (arg1,
                                                 rb_intern ("address"),
                                                 0);
-                  objc_object = NUM2ULONG (rb_objc_pointer);
+                  objc_object = (id)rb_objc_pointer;
                 }
               else
                 {


### PR DESCRIPTION
`objc_object` is `id` type.
But, `NUM2ULONG` returns `unsigned long` type.

This incompatible cast causes following warning:

``` log
rb_cairo_surface.c:1281:31: warning: incompatible integer to pointer conversion
assigning to 'id' (aka 'struct objc_object *') from 'unsigned long'
[-Wint-conversion]
objc_object = NUM2ULONG (rb_objc_pointer);
            ^
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```
