### PR TITLE
Enable tests using poppler

### DIFF
--- a/cairo.gemspec
+++ b/cairo.gemspec
@@ -41,5 +41,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency("test-unit-notify")
   s.add_development_dependency("rake-compiler")
   s.add_development_dependency("packnga")
-  # s.add_development_dependency("poppler")
+  s.add_development_dependency("poppler")
 end

--- a/test/test_context.rb
+++ b/test/test_context.rb
@@ -1,4 +1,5 @@
 require 'cairo'
+require 'poppler'
 require 'stringio'
 
 class ContextTest < Test::Unit::TestCase
@@ -106,7 +107,6 @@ class ContextTest < Test::Unit::TestCase
   sub_test_case("#tag") do
     setup do
       only_cairo_version(1, 15, 4)
-      omit("poppler 3.1.1 is required")
     end
 
     test("LINK") do

--- a/test/test_pdf_surface.rb
+++ b/test/test_pdf_surface.rb
@@ -1,8 +1,9 @@
+require 'poppler'
+
 class PDFSurfaceTest < Test::Unit::TestCase
   include CairoTestUtils
 
   def create_pdf
-    omit("poppler 3.1.1 is required")
     pdf = StringIO.new
     surface = Cairo::PDFSurface.new(pdf, 10, 20)
     yield(surface)
@@ -134,6 +135,6 @@ class PDFSurfaceTest < Test::Unit::TestCase
     pdf = create_pdf do |surface|
       surface.set_thumbnail_size(5, 10)
     end
-    assert_equal([5, 10], pdf[0].thumbnail_size)
+    assert_equal([true, 5, 10], pdf[0].thumbnail_size)
   end
 end


### PR DESCRIPTION
Recently I tried to update rcairo to 1.15.11,  then I've noticed that tests releated to poppler integration are disabled since 0b8739c338ed978233eda19299081c28dcc5c61f . Since we already have (ruby-gnome2) poppler 3.2.1, now we can enable these tests again?   

By the way the tests as they are fail at test: #set_thumbnail_size(PDFSurfaceTest):
```
================================================================================================================================================================
Failure: test: #set_thumbnail_size(PDFSurfaceTest)
/home/mtasaka/rpmbuild/fedora-specific/TMP/rubygem-cairo/master/GIT/rcairo/test/test_pdf_surface.rb:138:in `block in <class:PDFSurfaceTest>'
     135:     pdf = create_pdf do |surface|
     136:       surface.set_thumbnail_size(5, 10)
     137:     end
  => 138:     assert_equal([5, 10], pdf[0].thumbnail_size)
     139:   end
     140: end
<[5, 10]> expected but was
<[true, 5, 10]>

diff:
? [true, 5, 10]
```
Looks line the return value is also annotated: https://cgit.freedesktop.org/poppler/poppler/tree/glib/poppler-page.cc#n572
