### PR TITLE
Improve performance of Cairo::Point#distance

### DIFF
--- a/lib/cairo/point.rb
+++ b/lib/cairo/point.rb
@@ -1,7 +1,7 @@
 module Cairo
   class Point
     def distance(other)
-      Math.sqrt((other.x - x) ** 2 + (other.y - y) ** 2)
+      Math.hypot(other.x - x, other.y - y)
     end
   end
 end


### PR DESCRIPTION
Cairo::Point#distance can be simpler and faster using Math.hypot.

Benchmark:

```rb
require "benchmark_driver"

Benchmark.driver do |r|
  r.prelude <<~EOT
    require "cairo"

    module Cairo
      class Point
        def distance2(other)
          Math.hypot(other.x - x, other.y - y)
        end
      end
    end

    point_pairs = 200.times.map{ Cairo::Point.new(rand, rand) }.each_slice(2)
  EOT

  r.report "point_pairs.each{ |p1, p2| p1.distance(p2) }"
  r.report "point_pairs.each{ |p1, p2| p1.distance2(p2) }"
end
```

```
ruby 2.5.3p105 (2018-10-18 revision 65156) [x64-mingw32]
```

```
Comparison:
point_pairs.each{ |p1, p2| p1.distance2(p2) }:     38288.5 i/s
 point_pairs.each{ |p1, p2| p1.distance(p2) }:     23784.8 i/s - 1.61x  slower
```