### PR TITLE
Improve Context#to_ptr error message

### DIFF
--- a/ext/cairo/rb_cairo_context.c
+++ b/ext/cairo/rb_cairo_context.c
@@ -234,7 +234,11 @@ static VALUE
 cr_to_ptr (VALUE self)
 {
   if (NIL_P (rb_cairo__cFFIPointer))
-    return Qnil;
+  {
+    rb_raise (rb_eNotImpError,
+              "%s: ffi gem is required",
+              rb_id2name (rb_frame_this_func ()));
+  }
 
   return rb_funcall (rb_cairo__cFFIPointer, rb_intern ("new"),
                      1, PTR2NUM (_SELF));


### PR DESCRIPTION
Raise error message when ffi gem not found

`Cairo::Context#to_ptr`
This pull request is intended to raise an error message instead of returning nil when FFI gem is not found.
I tried to display a plot in a Ruby/GTK3 window using the GR Framework, but I couldn't. I had to trace the source code history to see why `to_ptr` returned nil. 

![image](https://user-images.githubusercontent.com/5798442/66967962-c10f4780-f0bd-11e9-9298-44d6e8a49cc0.png)

