### PR TITLE
gl: Correct arity argument for surface init methods

### DIFF
--- a/ext/cairo/rb_cairo_surface.c
+++ b/ext/cairo/rb_cairo_surface.c
@@ -2352,7 +2352,7 @@ Init_cairo_surface (void)
     rb_define_class_under (rb_mCairo, "GLTextureSurface", rb_cCairo_GLSurface);
 #ifdef RB_CAIRO_HAS_GL_SURFACE
   rb_define_method (rb_cCairo_GLSurface, "initialize",
-                    cr_gl_surface_initialize, 1);
+                    cr_gl_surface_initialize, -1);
 
   rb_define_method (rb_cCairo_GLSurface, "set_size",
                     cr_gl_surface_set_size, 2);
@@ -2366,7 +2366,7 @@ Init_cairo_surface (void)
   RB_CAIRO_DEF_SETTERS (rb_cCairo_GLSurface);
 
   rb_define_method (rb_cCairo_GLTextureSurface, "initialize",
-                    cr_gl_texture_surface_initialize, 1);
+                    cr_gl_texture_surface_initialize, -1);
 
   RB_CAIRO_DEF_SETTERS (rb_cCairo_GLTextureSurface);
 #endif


### PR DESCRIPTION
As reported in https://bugs.freebsd.org/271706, clang 16 has a new error about incompatible function types, which shows up when building rcairo:

```
rb_cairo_surface.c:2354:3: error: incompatible function pointer types passing 'VALUE (int, VALUE *, VALUE)' (aka 'unsigned long (int, unsigned long *, unsigned long)') to parameter of type 'VALUE (*)(VALUE, VALUE)' (aka 'unsigned long (*)(unsigned long, unsigned long)') [-Wincompatible-function-pointer-types]
  rb_define_method (rb_cCairo_GLSurface, "initialize",
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/local/include/ruby-3.1/ruby/internal/anyargs.h:287:135: note: expanded from macro 'rb_define_method'
#define rb_define_method(klass, mid, func, arity)           RBIMPL_ANYARGS_DISPATCH_rb_define_method((arity), (func))((klass), (mid), (func), (arity))
                                                                                                                                      ^~~~~~
/usr/local/include/ruby-3.1/ruby/internal/anyargs.h:276:1: note: passing argument to parameter here
RBIMPL_ANYARGS_DECL(rb_define_method, VALUE, const char *)
^
/usr/local/include/ruby-3.1/ruby/internal/anyargs.h:255:72: note: expanded from macro 'RBIMPL_ANYARGS_DECL'
RBIMPL_ANYARGS_ATTRSET(sym) static void sym ## _01(__VA_ARGS__, VALUE(*)(VALUE, VALUE), int); \
                                                                       ^
rb_cairo_surface.c:2368:3: error: incompatible function pointer types passing 'VALUE (int, VALUE *, VALUE)' (aka 'unsigned long (int, unsigned long *, unsigned long)') to parameter of type 'VALUE (*)(VALUE, VALUE)' (aka 'unsigned long (*)(unsigned long, unsigned long)') [-Wincompatible-function-pointer-types]
  rb_define_method (rb_cCairo_GLTextureSurface, "initialize",
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/local/include/ruby-3.1/ruby/internal/anyargs.h:287:135: note: expanded from macro 'rb_define_method'
#define rb_define_method(klass, mid, func, arity)           RBIMPL_ANYARGS_DISPATCH_rb_define_method((arity), (func))((klass), (mid), (func), (arity))
                                                                                                                                      ^~~~~~
/usr/local/include/ruby-3.1/ruby/internal/anyargs.h:276:1: note: passing argument to parameter here
RBIMPL_ANYARGS_DECL(rb_define_method, VALUE, const char *)
^
/usr/local/include/ruby-3.1/ruby/internal/anyargs.h:255:72: note: expanded from macro 'RBIMPL_ANYARGS_DECL'
RBIMPL_ANYARGS_ATTRSET(sym) static void sym ## _01(__VA_ARGS__, VALUE(*)(VALUE, VALUE), int); \
                                                                       ^
```

This is because `rb_define_method`'s last argument is the 'arity' of the method, and in case of `cr_gl_surface_initialize()` and `cr_gl_texture_surface_initialize()` it should be -1 to indicate a variable number of arguments.
